### PR TITLE
Implement start screen for game

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -39,6 +39,21 @@ async def connect_to_server():
         response = await websocket.recv()
         print(response)
 
+        # Wait for other players to connect
+        await websocket.send(json.dumps({"action": "wait_for_players"}))
+        response = await websocket.recv()
+        print(response)
+        response_data = json.loads(response)
+        if response_data.get("status") == "waiting":
+            print("Waiting for other players to connect...")
+            while response_data.get("status") == "waiting":
+                response = await websocket.recv()
+                response_data = json.loads(response)
+                print(response_data.get("message"))
+
+        if response_data.get("status") == "start_game":
+            print("All players connected. Starting the game...")
+
 
 if __name__ == "__main__":
     asyncio.run(connect_to_server())

--- a/display/start_screen.py
+++ b/display/start_screen.py
@@ -1,0 +1,15 @@
+class StartScreen:
+    def show_start_screen(self):
+        print("Welcome to the Game!")
+        print("1. Start Game")
+        print("2. Wait for Players")
+
+    def handle_user_input(self):
+        choice = input("Enter your choice: ")
+        if choice == "1":
+            return "start_game"
+        elif choice == "2":
+            return "wait_for_players"
+        else:
+            print("Invalid choice. Please try again.")
+            return self.handle_user_input()

--- a/display/wait_screen.py
+++ b/display/wait_screen.py
@@ -1,0 +1,15 @@
+class WaitScreen:
+    def show_wait_screen(self):
+        print("Waiting for other players to connect...")
+        print("1. Start Game")
+        print("2. Cancel")
+
+    def handle_user_input(self):
+        choice = input("Enter your choice: ")
+        if choice == "1":
+            return "start_game"
+        elif choice == "2":
+            return "cancel"
+        else:
+            print("Invalid choice. Please try again.")
+            return self.handle_user_input()

--- a/main.py
+++ b/main.py
@@ -25,6 +25,8 @@ import time
 from src.models.base_types import EffectResult
 from src.services.session_management import SessionManagementService
 from src.services.game_state import GameStateService
+from display.start_screen import StartScreen
+from display.wait_screen import WaitScreen
 
 # Configure logging
 logging.basicConfig(
@@ -66,6 +68,18 @@ def main():
     boss_service = BossService()
     session_service = SessionManagementService()
     game_state_service = GameStateService()
+    start_screen = StartScreen()
+    wait_screen = WaitScreen()
+
+    # Show start screen
+    start_screen.show_start_screen()
+    start_choice = start_screen.handle_user_input()
+
+    if start_choice == "wait_for_players":
+        wait_screen.show_wait_screen()
+        wait_choice = wait_screen.handle_user_input()
+        if wait_choice == "cancel":
+            return
 
     # Player authentication
     session_service.show_login_screen()


### PR DESCRIPTION
Implement a start screen and wait screen for the game.

* Add `display/start_screen.py` to implement a start screen class with methods to show the start screen and handle user input.
* Add `display/wait_screen.py` to implement a wait screen class with methods to show the wait screen and handle user input.
* Modify `main.py` to import and use the start screen and wait screen classes, and update the `main` function to show these screens before starting the game.
* Modify `client/client.py` to add functionality for waiting for other players to connect before starting the game, and update the `connect_to_server` function to handle this waiting process.
* Modify `src/services/server.py` to add logic for a start screen where players can wait for others to connect or start the game, and update the `handle_client` function to manage player connections and game start.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mericozkayagan/Terminal-Quest/pull/4?shareId=ebb33964-777a-4b08-adad-43d287ede0fe).